### PR TITLE
Use a Set to improve performance

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -15,4 +15,4 @@ with open('verified.csv', 'rt') as fp:
 db = list(set(db))
 
 with open('ext/db.js', 'w+t') as fp:
-	fp.write('const veryfied_users = %s;' % json.dumps(db))
+	fp.write('const veryfied_users = new Set(%s);' % json.dumps(db))

--- a/ext/veryfied.js
+++ b/ext/veryfied.js
@@ -32,7 +32,7 @@ function isProfileLink(a) {
 // returns true if the user screen name contained in the anchor is in the database.
 function isVeryfiedLink(a) {
 	var screen_name = a.getAttribute('href').substring(1).toLowerCase();
-	return veryfied_users.includes(screen_name);
+	return veryfied_users.has(screen_name);
 }
 
 // returns true if the user screen name contained in the div is in the database.
@@ -40,7 +40,7 @@ function isVeryfiedDiv(div) {
 	for (const span of div.querySelectorAll('span')) {
 		if (span.textContent.length > 0 && span.textContent[0] == '@') {
 			var screen_name = span.textContent.substring(1).toLowerCase();
-			return veryfied_users.includes(screen_name);
+			return veryfied_users.has(screen_name);
 		}
 	}
 	return false;


### PR DESCRIPTION
Current method checks the whole array for each profile, O(n * k) operations.

Replaced it with a Set to improve perf. Small and negligible perf impact on page load to create the Set, but then it's O(1) ✌️

## Performance benchmark

A 30s recording scrolling the timeline.

Before:

![2022-11-10_01-39-44](https://user-images.githubusercontent.com/26366184/200973091-eed7224f-a876-4e1f-8f86-65d4938ef026.png)

After:

![2022-11-10_01-44-05](https://user-images.githubusercontent.com/26366184/200973104-dffa1fb9-cc8f-4dfc-b7d2-5e617169ee74.png)
